### PR TITLE
Fix the incorrect docs.rs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ let signature: String = creator.create_signature("com.test.product", "com.test.o
 
 ## Documentation
 
-* The full documentation is available at [docs.rs](https://docs.rs/google_maps/)
+* The full documentation is available at [docs.rs](https://docs.rs/app-store-server-library/)
 * [WWDC Video](https://developer.apple.com/videos/play/wwdc2023/10143/)
 
 ## References


### PR DESCRIPTION
Originally pointed to the docs for the google_maps crate.

<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## What was done?
<!--- Describe your changes in detail -->
I changed a link in the readme file.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

it hasn't.


## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->

nothing has been broken.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ x] I have performed a self-review of my own code
- [ -] I have commented my code, particularly in hard-to-understand areas
- [ -] I have added or updated relevant unit/integration/functional/e2e tests
- [ -] I have made corresponding changes to the documentation

