### PR TITLE
feat: Add ONE_TIME_CHARGE notification type; bug fix for README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ async fn main() {
     
     let client = AppStoreServerApiClient::new(encoded_key, key_id, issuer_id, bundle_id, environment);
     match client.request_test_notification().await {
-        Ok(res) => {
+        Ok(response) => {
             println!("{}", response.test_notification_token);
         }
         Err(err) => {

--- a/src/api_client.rs
+++ b/src/api_client.rs
@@ -25,10 +25,10 @@ use crate::primitives::transaction_info_response::TransactionInfoResponse;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct APIException {
-    http_status_code: u16,
-    api_error: Option<APIError>,
-    raw_api_error: Option<i64>,
-    error_message: Option<String>,
+    pub http_status_code: u16,
+    pub api_error: Option<APIError>,
+    pub raw_api_error: Option<i64>,
+    pub error_message: Option<String>,
 }
 
 impl fmt::Display for APIException {

--- a/src/primitives/notification_type_v2.rs
+++ b/src/primitives/notification_type_v2.rs
@@ -41,4 +41,6 @@ pub enum NotificationTypeV2 {
     RefundReversed,
     #[serde(rename = "EXTERNAL_PURCHASE_TOKEN")]
     ExternalPurchaseToken,
+    #[serde(rename = "ONE_TIME_CHARGE")]
+    OneTimeCharge,
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

**added**
Apple added ONE_TIME_CHARGE notification type for one-time non-recurring purchases [ref](https://developer.apple.com/documentation/appstoreservernotifications/app_store_server_notifications_changelog#4408521)

**fixed**
Make fields of `APIException` public so that example in README works, also fix typo `res` to `response` in the README example

## What was done?
<!--- Describe your changes in detail -->


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
ONE_TIME_CHARGE notification tested in Sandbox

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

