### PR TITLE
Add feature flags for TLS backend selection

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ base64 = "0.22.1"
 asn1-rs = { version = "0.7.0", optional = true }
 
 # Networking
-reqwest = { version = "0.12.12", features = ["json"], optional = true }
+reqwest = { version = "0.12.12", default-features = false, features = ["json"], optional = true }
 
 # Utils
 thiserror = "2.0.11"
@@ -44,6 +44,7 @@ tokio = { version = "1.43.0", features = ["test-util", "macros"] }
 jsonwebtoken = { version = "9.3.0", features = ["use_pem"] }
 
 [features]
-api-client = ["dep:reqwest"]
+api-client = ["dep:reqwest", "reqwest/rustls-tls-native-roots"]
+api-client-native-tls = ["dep:reqwest", "reqwest/default-tls"]
 receipt-utility = ["dep:asn1-rs", "dep:regex"]
 


### PR DESCRIPTION
## Issue being fixed or feature implemented
Currently, the crate is fixed to native-tls via reqwest's default features when using the api-client feature.
This causes issues in environments where rustls is preferred or required. For example, OpenSSL crashes in containerized environments with high concurrency.

## What was done?
- Makes rustls the default (seems to be the route forward for lots of crates these days)
- Adds api-client-native-tls feature for backwards compatibility

## How Has This Been Tested?
Running in my own project

## Breaking Changes
Theoretically, rustls should be a drop-in replacement for native-tls. New api-client-native-tls feature provided for those that prefer it for [whatever reason](https://users.rust-lang.org/t/any-reasons-to-prefer-native-tls-over-rustls/37626/7).

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests (n/a)
- [ ] I have made corresponding changes to the documentation