### PR TITLE
feat: Add support for Set App Account Token endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,4 @@ sdk/lib/Cargo.lock
 **/*.rs.bk
 
 .env
+.claude

--- a/resources/models/familyTransactionNotSupportedError.json
+++ b/resources/models/familyTransactionNotSupportedError.json
@@ -1,0 +1,4 @@
+{
+  "errorCode": 4000185,
+  "errorMessage": "Invalid request. Family Sharing transactions aren't supported by this endpoint."
+}

--- a/resources/models/invalidAppAccountTokenUUIDError.json
+++ b/resources/models/invalidAppAccountTokenUUIDError.json
@@ -1,0 +1,4 @@
+{
+  "errorCode": 4000183,
+  "errorMessage": "Invalid request. The app account token field must be a valid UUID."
+}

--- a/resources/models/transactionIdNotOriginalTransactionId.json
+++ b/resources/models/transactionIdNotOriginalTransactionId.json
@@ -1,0 +1,4 @@
+{
+  "errorCode": 4000187,
+  "errorMessage": "Invalid request. The transaction ID provided is not an original transaction ID."
+}

--- a/src/primitives/error_payload.rs
+++ b/src/primitives/error_payload.rs
@@ -172,6 +172,21 @@ pub enum APIError {
     /// [AppTransactionIdNotSupportedError](https://developer.apple.com/documentation/appstoreserverapi/apptransactionidnotsupportederror)
     AppTransactionIdNotSupportedError = 4000048,
 
+    /// An error that indicates the app account token value is not a valid UUID.
+    ///
+    /// [InvalidAppAccountTokenUUID](https://developer.apple.com/documentation/appstoreserverapi/invalidappaccounttokenuuiderror)
+    InvalidAppAccountTokenUUID = 4000183,
+
+    /// An error that indicates the transaction is for a product the customer obtains through Family Sharing, which the endpoint doesn't support.
+    ///
+    /// [FamilyTransactionNotSupported](https://developer.apple.com/documentation/appstoreserverapi/familytransactionnotsupportederror)
+    FamilyTransactionNotSupported = 4000185,
+
+    /// An error that indicates the endpoint expects an original transaction identifier.
+    ///
+    /// [TransactionIdNotOriginalTransactionId](https://developer.apple.com/documentation/appstoreserverapi/transactionidnotoriginaltransactioniderror)
+    TransactionIdNotOriginalTransactionId = 4000187,
+
     /// An error that indicates the subscription doesn't qualify for a renewal-date extension due to its subscription state.
     /// [Documentation](https://developer.apple.com/documentation/appstoreserverapi/subscriptionextensionineligibleerror)
     SubscriptionExtensionIneligible = 4030004,

--- a/src/primitives/mod.rs
+++ b/src/primitives/mod.rs
@@ -50,6 +50,7 @@ pub mod summary;
 pub mod transaction_history_request;
 pub mod transaction_info_response;
 pub mod transaction_reason;
+pub mod update_app_account_token_request;
 pub mod user_status;
 pub mod external_purchase_token;
 pub mod consumption_request_reason;

--- a/src/primitives/update_app_account_token_request.rs
+++ b/src/primitives/update_app_account_token_request.rs
@@ -1,0 +1,50 @@
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+/// The request body for the Set App Account Token endpoint.
+///
+/// # References
+/// [UpdateAppAccountTokenRequest](https://developer.apple.com/documentation/appstoreserverapi/updateappaccounttokenrequest)
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdateAppAccountTokenRequest {
+    /// The UUID that an app optionally generates to map a customer's in-app purchase with its resulting App Store transaction.
+    ///
+    /// # References
+    /// [appAccountToken](https://developer.apple.com/documentation/appstoreserverapi/appaccounttoken)
+    pub app_account_token: Uuid,
+}
+
+impl UpdateAppAccountTokenRequest {
+    /// Creates a new UpdateAppAccountTokenRequest with the specified app account token.
+    pub fn new(app_account_token: Uuid) -> Self {
+        Self { app_account_token }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json;
+
+    #[test]
+    fn test_serialization() {
+        let token = Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap();
+        let request = UpdateAppAccountTokenRequest::new(token);
+        
+        let json = serde_json::to_string(&request).unwrap();
+        let expected = r#"{"appAccountToken":"550e8400-e29b-41d4-a716-446655440000"}"#;
+        assert_eq!(json, expected);
+    }
+
+    #[test]
+    fn test_deserialization() {
+        let json = r#"{"appAccountToken":"550e8400-e29b-41d4-a716-446655440000"}"#;
+        let request: UpdateAppAccountTokenRequest = serde_json::from_str(json).unwrap();
+        
+        assert_eq!(
+            request.app_account_token.to_string(),
+            "550e8400-e29b-41d4-a716-446655440000"
+        );
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Adding implementation for calling the Set App Account Token S2S using App Store Server Library.

For more info, please visit our developer documentation: https://developer.apple.com/documentation/appstoreserverapi/set-app-account-token

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

