### PR TITLE
feat: Add support for App Store Server Notifications v2.17

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,15 +27,15 @@ serde = { version = "1.0.219", features = ["derive"] }
 serde_json = { version = "1.0.142" }
 serde_with = { version = "3.14.0", features = ["chrono"] }
 serde_repr = "0.1.20"
-uuid = { version = "1.17.0", features = ["serde", "v4"] }
+uuid = { version = "1.18.0", features = ["serde", "v4"] }
 chrono = { version = "0.4.41", features = ["serde"] }
 base64 = "0.22.1"
 
 # Networking
-reqwest = { version = "0.12.22", default-features = false, features = ["json"], optional = true }
+reqwest = { version = "0.12.23", default-features = false, features = ["json"], optional = true }
 
 # Utils
-thiserror = "2.0.12"
+thiserror = "2.0.15"
 
 # Tools
 regex = { version = "1.11.1", optional = true }

--- a/src/primitives/external_purchase_token.rs
+++ b/src/primitives/external_purchase_token.rs
@@ -1,3 +1,4 @@
+use crate::primitives::token_type::TokenType;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use serde_with::formats::Flexible;
@@ -34,4 +35,17 @@ pub struct ExternalPurchaseToken {
     /// [bundleId](https://developer.apple.com/documentation/appstoreservernotifications/bundleid)
     #[serde(rename = "bundleId")]
     pub bundle_id: Option<String>,
+
+    /// The UNIX time, in milliseconds, when a token expires. This field is present only for custom link tokens.
+    ///
+    /// [tokenExpirationDate](https://developer.apple.com/documentation/appstoreservernotifications/tokenexpirationdate)
+    #[serde(rename = "tokenExpirationDate")]
+    #[serde_as(as = "Option<TimestampMilliSeconds<String, Flexible>>")]
+    pub token_expiration_date: Option<DateTime<Utc>>,
+
+    /// The type of an external purchase custom link token.
+    ///
+    /// [tokenType](https://developer.apple.com/documentation/appstoreservernotifications/tokentype)
+    #[serde(rename = "tokenType")]
+    pub token_type: Option<TokenType>,
 }

--- a/src/primitives/mod.rs
+++ b/src/primitives/mod.rs
@@ -56,3 +56,4 @@ pub mod external_purchase_token;
 pub mod consumption_request_reason;
 pub mod refund_preference;
 pub mod purchase_platform;
+pub mod token_type;

--- a/src/primitives/subtype.rs
+++ b/src/primitives/subtype.rs
@@ -39,4 +39,8 @@ pub enum Subtype {
     Failure,
     #[serde(rename = "UNREPORTED")]
     Unreported,
+    #[serde(rename = "ACTIVE_TOKEN_REMINDER")]
+    ActiveTokenReminder,
+    #[serde(rename = "CREATED")]
+    Created,
 }

--- a/src/primitives/token_type.rs
+++ b/src/primitives/token_type.rs
@@ -1,0 +1,17 @@
+use serde::{Deserialize, Serialize};
+
+/// The type of an external purchase custom link token.
+/// The token type field is present only for custom link tokens.
+/// For more information on tokens, see Receiving and decoding external purchase tokens.
+///
+/// [tokenType](https://developer.apple.com/documentation/appstoreservernotifications/tokentype)
+#[derive(Debug, Clone, Deserialize, Serialize, Hash, PartialEq, Eq)]
+pub enum TokenType {
+    /// A token type that indicates an initial acquisition.
+    #[serde(rename = "ACQUISITION")]
+    Acquisition,
+
+    /// A token type that indicates usage of App Store services.
+    #[serde(rename = "SERVICES")]
+    Services,
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Add support for App Store Server Notifications v2.17

https://developer.apple.com/documentation/appstoreservernotifications/app-store-server-notifications-changelog#June-26-2025

## What was done?
<!--- Describe your changes in detail -->
- [x] Added the `ACTIVE_TOKEN_REMINDER` and `CREATED` values to [subtype](https://developer.apple.com/documentation/appstoreservernotifications/subtype), which can appear in notifications with an `EXTERNAL_PURCHASE_TOKEN` [notificationType](https://developer.apple.com/documentation/appstoreservernotifications/notificationtype).
- [x] Updated [externalPurchaseToken](https://developer.apple.com/documentation/appstoreservernotifications/externalpurchasetoken) to include the new fields [tokenType](https://developer.apple.com/documentation/appstoreservernotifications/tokentype) and [tokenExpirationDate](https://developer.apple.com/documentation/appstoreservernotifications/tokenexpirationdate).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tests

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
N/A

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

