### PR TITLE
Fix base64URL to base64 conversion character mapping

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -3,7 +3,7 @@ use base64::{DecodeError, Engine};
 
 /// Converts a base64URL-encoded string to a standard base64-encoded string.
 ///
-/// Replaces '/' with '+' and '_' with '-', and adds padding if needed.
+/// Replaces '-' with '+' and '_' with '/', and adds padding if needed.
 ///
 /// # Examples
 ///
@@ -14,8 +14,8 @@ use base64::{DecodeError, Engine};
 /// ```
 pub(crate) fn base64_url_to_base64(encoded_string: &str) -> String {
     let replaced_string = encoded_string
-        .replace('/', "+")
-        .replace('_', "-");
+        .replace('-', "+")
+        .replace('_', "/");
 
     if replaced_string.len() % 4 != 0 {
         return replaced_string.clone() + &"=".repeat(4 - replaced_string.len() % 4);


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- Same fix. https://github.com/apple/app-store-server-library-swift/pull/107

## What was done?
<!--- Describe your changes in detail -->
   The conversion between base64URL and standard base64 had incorrect character mappings. Updated both directions:
   - base64URLToBase64: now correctly maps `-` → `+` and `_` → `/`
   - base64ToBase64URL: now correctly maps `+` → `-` and `/` → `_`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

