### PR TITLE
fix: give the reqwest transport its TLS backend back (#115)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,8 +54,11 @@ jsonwebtoken = { version = "10.3.0", features = ["use_pem"] }
 
 [features]
 api-client = ["dep:http"]
-api-client-reqwest = ["api-client", "dep:reqwest"]
-api-client-reqwest-native-tls = ["api-client", "dep:reqwest", "reqwest/native-tls"]
+api-client-reqwest = ["api-client", "dep:reqwest", "reqwest-tls-rustls"]
+api-client-reqwest-native-tls = ["api-client", "dep:reqwest", "reqwest-tls-native"]
+# reqwest TLS backend markers; the reqwest transport asserts one is set.
+reqwest-tls-rustls = ["reqwest/rustls"]
+reqwest-tls-native = ["reqwest/native-tls"]
 receipt-utility = ["dep:regex"]
 ocsp = ["dep:x509-ocsp", "dep:reqwest", "reqwest/blocking"]
 

--- a/src/api_client/reqwest_transport/mod.rs
+++ b/src/api_client/reqwest_transport/mod.rs
@@ -1,1 +1,9 @@
+// Without a TLS backend, reqwest cannot do HTTPS and every API call fails at
+// connect time (regressed in 4.3.0). Fail at build time instead of runtime.
+#[cfg(not(any(feature = "reqwest-tls-rustls", feature = "reqwest-tls-native")))]
+compile_error!(
+    "reqwest transport enabled without a TLS backend; use `api-client-reqwest` \
+     (rustls) or `api-client-reqwest-native-tls` (native-tls)."
+);
+
 pub mod reqwest_http_transport;


### PR DESCRIPTION
#109 dropped the TLS feature off api-client-reqwest, and since reqwest is default-features = false that left it with no TLS at all, so every HTTPS call fails to connect and the transport turns it into a 503 (the "503 on every call" from #115).

Wire rustls back onto api-client-reqwest (native-tls stays on the -native-tls feature), each via its own marker feature, plus a compile_error! so building the transport without a TLS backend fails loudly instead of at runtime.